### PR TITLE
Adds Prawn 0.11.1+ support (Issue #1) from vspan's code comment.

### DIFF
--- a/lib/prawn/js.rb
+++ b/lib/prawn/js.rb
@@ -81,7 +81,11 @@ module Prawn
     # See section 3.6.3 and table 3.28 in the PDF spec.
     #
     def javascript
-      names.data[:JavaScript] ||= ref!(Prawn::NameTree::Node.new(self, NAME_TREE_CHILDREN_LIMIT))
+      if defined? Prawn::NameTree 
+        names.data[:JavaScript] ||= ref!(Prawn::NameTree::Node.new(self, NAME_TREE_CHILDREN_LIMIT)) 
+      else 
+        names.data[:JavaScript] ||= ref!(Prawn::Core::NameTree::Node.new(self, NAME_TREE_CHILDREN_LIMIT)) 
+      end 
     end
 
   end

--- a/prawn-js.gemspec
+++ b/prawn-js.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.version = "0.7.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["James Healy"]
+  s.authors = ["James Healy","Nick Gorbikof"]
   s.date = %q{2009-06-18}
   s.description = %q{A small extension to prawn that simplifies embedding JavaScript in your PDF files}
   s.email = %q{pat@freelancing-gods.com}
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{prawn}
   s.summary = %q{A small extension to prawn that makes it possible to embed JavaScript fragment in  your document that respond to events.}
-  s.add_dependency('prawn-core', '>=0.6.1')
+  s.add_dependency('prawn', '>=0.12.0')
 end


### PR DESCRIPTION
...+

Resolves issue #1: https://github.com/yob/prawn-js/issues/
1

"Discovered a better solution, here is the javascript method replaced,
this will then work with both old (0.8.4) and new (0.11.1+) Prawn."
